### PR TITLE
Turned notepad/input into fixed 32-bit integers.

### DIFF
--- a/lang.c
+++ b/lang.c
@@ -6,7 +6,7 @@
 
 #pragma GCC diagnostic ignored "-Wunused-result"
 
-int mem, input;
+int32_t mem, input;
 
 struct {
   int pos, faces[7];
@@ -16,7 +16,7 @@ int parens, jumpnum;
 int rubiksnotation(char);
 int execute(int,int);
 int do_jump(void);
-int _faceval(int);
+int32_t _faceval(int);
 
 FILE *in;
 
@@ -98,7 +98,7 @@ int do_jump(void)
         jumpnum--;
 }
 
-int _faceval(int face)
+int32_t _faceval(int face)
 {
     if (face == 7)
         return input;


### PR DESCRIPTION
This will add some consistency to the interpreter, including with how overflows are handled (hopefully). To be honest, I'd prefer 64-bit because there aren't a lot of variables and 64-bit is large enough to handle almost every use, but 32-bit is more widely supported than 64-bit.
Please note that this is untested. I don't have a C compiler on this computer, so I'd have to remote into a terminal, clone the repo, make the change, then test it there (I'm too lazy).